### PR TITLE
Increase the cache version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,4 @@ jobs:
     uses: voxpupuli/gha-puppet/.github/workflows/basic.yml@v1
     with:
       rubocop: false
+      cache-version: '1'

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'puppet-lint-strict_indent-check', {"groups"=>["test"]}
 gem 'puppet-lint-undef_in_function-check', {"groups"=>["test"]}
 gem 'voxpupuli-test', '~> 1.4', {"groups"=>["test"]}
 gem 'github_changelog_generator', '>= 1.15.0', {"groups"=>["development"]}
-gem 'puppet_metadata', '~> 0.3'
+gem 'puppet_metadata', '~> 1.3'
 gem 'puppet-blacksmith', '>= 6.0.0', {"groups"=>["development"]}
 gem 'voxpupuli-acceptance', '~> 1.0', {"groups"=>["system_tests"]}
 gem 'puppetlabs_spec_helper', {"groups"=>["system_tests"]}


### PR DESCRIPTION
This works around the broken cache which includes Psych 4 on Ruby 2.5.

<del>Testing https://github.com/voxpupuli/gha-puppet/pull/13.</del>