### PR TITLE
use `ip` not `ipaddress` as networking fact

### DIFF
--- a/templates/motd.erb
+++ b/templates/motd.erb
@@ -12,7 +12,7 @@ warning.
 
 <%= @facts['os']['name'] %> <%= @facts['os']['release']['full'] %> <%= @facts['os']['architecture'] %>
 
-FQDN:      <%= @facts['networking']['fqdn'] %> (<%= @facts['networking']['ipaddress'] %>)
+FQDN:      <%= @facts['networking']['fqdn'] %> (<%= @facts['networking']['ip'] %>)
 Processor: <%= @facts['processors']['count'] %>x <%= @facts['processors']['models'][0] %>
 Kernel:    <%= @facts['kernelrelease'] %>
 Memory:    <%= @facts['memory']['system']['total'] %>


### PR DESCRIPTION
`ipaddress` doesn't exist

Fixes: 5e9eae7c47f47bfa53558c75492967db37070a00